### PR TITLE
Fix HTTP header

### DIFF
--- a/src/cohttp_async_websocket.ml
+++ b/src/cohttp_async_websocket.ml
@@ -372,7 +372,7 @@ module Server = struct
         Response.make
           ()
           ~encoding:(Header.get_transfer_encoding headers)
-          ~status:(`Code 101)
+          ~status:`Switching_protocols
           ~headers
       in
       return (`Expert (response, io_handler))


### PR DESCRIPTION
Cohttp_async_websocket currently uses ``~status:(`Code 101)`` to indicate the HTTP response code to Cohttp. Unfortunately, this results in an invalid HTTP header being sent, which causes Safari to be unable to open a websocket connection.

Using `` `Code 101`` rather than the "official" constructor `` `Switching_protocols`` causes Cohttp to send a header like:

`HTTP/1.1 101`

instead of:

`HTTP/1.1 101 Switching protocols`

This seems to be accepted just fine by Chrome, but Safari objects to this and throws "No response code found". You can see why this happens by looking at [the relevant parsing code](https://github.com/WebKit/WebKit/blob/main/Source/WebCore/Modules/websockets/WebSocketHandshake.cpp#L450) in Webkit.

Arguably this is a bug in Cohttp, which should perhaps recognise 101 as one of the codes whose full name it knows. But fixing it in this library seems good too.